### PR TITLE
chore: minimal current project listener

### DIFF
--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -14,6 +14,10 @@ export type BackendEvents = DefineEvents<{
     totalSize: string;
     caidoTotalSize: string;
   }) => void;
+  "bytecap:project-changed": (data: {
+    projectName: string | null;
+    projectId: string | null;
+  }) => void;
 }>;
 
 interface FileInfo {
@@ -312,5 +316,19 @@ export function init(sdk: BytecapBackendSDK) {
   sdk.console.log("Bytecap backend starting...");
   sdk.api.register("getWorkspaceFiles", getWorkspaceFiles);
   sdk.api.register("checkFileSizeThresholds", checkFileSizeThresholds);
+
+  // Listen for project changes
+  sdk.events.onProjectChange((sdk, project) => {
+    const projectName = project?.getName() ?? null;
+    const projectId = project?.getId() ?? null;
+    sdk.console.log(`Project changed to: ${projectName}`);
+    
+    // Send event to frontend to refresh data
+    sdk.api.send("bytecap:project-changed", {
+      projectName,
+      projectId
+    });
+  });
+
   sdk.console.log("Bytecap backend initialized successfully");
 }

--- a/packages/frontend/src/views/App.vue
+++ b/packages/frontend/src/views/App.vue
@@ -248,9 +248,9 @@ onMounted(() => {
     scanSummary.value = summary;
   });
 
-  // Listen for project changes and automatically refresh
-  sdk.projects.onCurrentChanged(() => {
-    console.log("Project changed, refreshing workspace files...");
+  // Listen for project changes and refresh data
+  sdk.backend.onEvent("bytecap:project-changed", (data) => {
+    console.log(`Project changed to: ${data.projectName}`);
     loadWorkspaceFiles();
   });
 

--- a/packages/frontend/src/views/App.vue
+++ b/packages/frontend/src/views/App.vue
@@ -30,11 +30,37 @@ interface DirectoryInfo {
 // Retrieve the SDK instance to interact with the backend
 const sdk = useSDK();
 
-// Reactive state
-const thresholdMB = ref(10);
-const enableWarnings = ref(true);
-const warningAt75Percent = ref(true);
-const warningAt90Percent = ref(true);
+// Load settings from localStorage with defaults
+const loadSettings = () => {
+  const saved = localStorage.getItem('bytecap-settings');
+  if (saved) {
+    try {
+      return JSON.parse(saved);
+    } catch {
+      return {};
+    }
+  }
+  return {};
+};
+
+// Save settings to localStorage
+const saveSettings = () => {
+  const settings = {
+    thresholdMB: thresholdMB.value,
+    enableWarnings: enableWarnings.value,
+    warningAt75Percent: warningAt75Percent.value,
+    warningAt90Percent: warningAt90Percent.value,
+  };
+  localStorage.setItem('bytecap-settings', JSON.stringify(settings));
+};
+
+const savedSettings = loadSettings();
+
+// Reactive state with persisted values
+const thresholdMB = ref(savedSettings.thresholdMB ?? 10);
+const enableWarnings = ref(savedSettings.enableWarnings ?? true);
+const warningAt75Percent = ref(savedSettings.warningAt75Percent ?? true);
+const warningAt90Percent = ref(savedSettings.warningAt90Percent ?? true);
 const workspaceFiles = ref<DirectoryInfo>({
   files: [],
   totalSize: 0,
@@ -127,6 +153,9 @@ const onRefreshClick = async () => {
 
 // Apply settings and check thresholds manually
 const applySettings = async () => {
+  // Save settings to localStorage
+  saveSettings();
+
   // Clear any existing notifications first
   clearAllNotifications();
 

--- a/packages/frontend/src/views/App.vue
+++ b/packages/frontend/src/views/App.vue
@@ -248,6 +248,12 @@ onMounted(() => {
     scanSummary.value = summary;
   });
 
+  // Listen for project changes and automatically refresh
+  sdk.projects.onCurrentChanged(() => {
+    console.log("Project changed, refreshing workspace files...");
+    loadWorkspaceFiles();
+  });
+
   loadWorkspaceFiles();
 });
 </script>


### PR DESCRIPTION
# minimal current project listener for hot reload

The current implementation only refreshes when the user manually clicks "Refresh Files" or when the component first loads, which explains why you see stale data after workspace switches.

**Key Changes:**

- [ ] Now, the plugin will automatically detect the change and refresh to show the files from the new workspace directory instead of staying stuck on the old one

**Added:**

- [ ] minimal current project listener



---

## Generated Summary

- Added new "bytecap:project-changed" event in the backend to notify frontend of project changes.
- Implemented a project change listener in the backend that logs the new project name and sends the event with project details.
- Integrated localStorage persistence in the frontend for user settings (thresholdMB, enableWarnings, warningAt75Percent, warningAt90Percent).
- Updated the frontend to load persisted settings on initialization.
- Configured the frontend to listen for the "bytecap:project-changed" event and refresh workspace files upon detecting a project change.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


## Generated Summary

- Added a listener for project changes using sdk.projects.onCurrentChanged.
- Refreshes workspace files automatically by invoking loadWorkspaceFiles when the project changes.
- Includes a console log to aid debugging of the auto-refresh functionality.
- Improves user experience by ensuring that workspace files are always up-to-date.

This summary was generated with ❤️ by [rigging](https://docs.dreadnode.io/rigging/)


<!-- Delete any sections that are not applicable -->
<!-- Add screenshots or code examples if relevant -->
